### PR TITLE
Select approptiate function for sorting installed plugins

### DIFF
--- a/Template/plugin/show.php
+++ b/Template/plugin/show.php
@@ -1,6 +1,6 @@
 <?php
 function sortPlugins(&$arr) {
-  usort($arr, fn($a, $b) => strtolower($a->getPluginName()) <=> strtolower($b->getPluginName()));
+  uasort($arr, fn($a, $b) => strtolower($a->getPluginName()) <=> strtolower($b->getPluginName()));
 }
 ?>
 <?php if (! empty($incompatible_plugins)): ?>


### PR DESCRIPTION
This fixes the broken 'Uninstall' link, which was introduced by my last patch. Sorry for the inconvenience.